### PR TITLE
Allow runtime distribution override

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Blazing fast [TPCH] benchmark data generator, in pure Rust with zero dependencie
 1. Blazing Speed 🚀
 2. Obsessively Tested 📋
 3. Fully parallel, streaming, constant memory usage 🧠
+4. Custom distributions at runtime via `--dists-path` 📊
 
 ## Try it now
 
@@ -70,7 +71,7 @@ the output of this crate with [`dbgen`] as part of every checkin. See
   format. It depends on the arrow-rs library
 
 - [`tpchgen-cli`](tpchgen-cli) is a [`dbgen`] compatible CLI tool that generates
-  benchmark dataset using multiple processes.
+  benchmark dataset using multiple processes and supports custom distributions via `--dists-path`.
 
 [Apache Arrow]: https://arrow.apache.org/
 [`dbgen`]: https://github.com/electrum/tpch-dbgen

--- a/tpchgen-cli/README.md
+++ b/tpchgen-cli/README.md
@@ -65,6 +65,15 @@ for PART in `seq 2 3`; do
 done
 ```
 
+## Custom distributions
+
+To use a custom distribution file, pass `--dists-path`:
+
+```shell
+# load distributions from my.dss
+tpchgen-cli -s 10 --dists-path my.dss
+```
+
 ## Performance
 
 | Scale Factor | `tpchgen-cli` | DuckDB     | DuckDB (proprietary) |

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -133,6 +133,10 @@ struct Cli {
     /// Typical values range from 10MB to 100MB.
     #[arg(long, default_value_t = DEFAULT_PARQUET_ROW_GROUP_BYTES)]
     parquet_row_group_bytes: i64,
+
+    /// Path to a custom distributions file
+    #[arg(long)]
+    dists_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -248,6 +252,10 @@ async fn main() -> io::Result<()> {
 impl Cli {
     /// Main function to run the generation
     async fn main(self) -> io::Result<()> {
+        if let Some(path) = &self.dists_path {
+            Distributions::init_from_path(path)?;
+        }
+
         if self.verbose {
             // explicitly set logging to info / stdout
             env_logger::builder().filter_level(LevelFilter::Info).init();

--- a/tpchgen/README.md
+++ b/tpchgen/README.md
@@ -3,6 +3,8 @@
 This crate provides the core data generator logic for TPC-H. It has no
 dependencies and is easy to embed in any other Rust projects.
 
+Distributions can be overridden at runtime using `Distributions::init_from_path` to load values from a custom file.
+
 See the [docs.rs page](https://docs.rs/tpchgen/latest/tpchgen/) for API and the
 the tpchgen [README.md](https://github.com/clflushopt/tpchgen-rs) for more
 information on the project.


### PR DESCRIPTION
## Summary
- allow loading distributions from external file at runtime
- add cli option `--dists-path` to specify custom distributions

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68baec54a318832cae98da293986dc82