### PR TITLE
Require explicit distribution file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Blazing fast [TPCH] benchmark data generator, in pure Rust with zero dependencie
 1. Blazing Speed 🚀
 2. Obsessively Tested 📋
 3. Fully parallel, streaming, constant memory usage 🧠
-4. Custom distributions at runtime via `--dists-path` 📊
+4. Distributions provided at runtime via required `--dists-path` 📊
 
 ## Try it now
 
@@ -71,7 +71,7 @@ the output of this crate with [`dbgen`] as part of every checkin. See
   format. It depends on the arrow-rs library
 
 - [`tpchgen-cli`](tpchgen-cli) is a [`dbgen`] compatible CLI tool that generates
-  benchmark dataset using multiple processes and supports custom distributions via `--dists-path`.
+  benchmark dataset using multiple processes and requires a distributions file via `--dists-path`.
 
 [Apache Arrow]: https://arrow.apache.org/
 [`dbgen`]: https://github.com/electrum/tpch-dbgen

--- a/tests/conformance.sh
+++ b/tests/conformance.sh
@@ -37,7 +37,7 @@ for SF in "${SCALE_FACTORS[@]}"; do
     
     # Generate data using Rust implementation
     echo "Generating data with Rust implementation at SF=${SF}..."
-    cargo run --release --bin tpchgen-cli -- --scale-factor "${SF}" --output-dir "${RUST_DIR}"
+    cargo run --release --bin tpchgen-cli -- --scale-factor "${SF}" --output-dir "${RUST_DIR}" --dists-path tpchgen/src/dists.dss
     
     # Generate data using C implementation
     echo "Generating data with C implementation at SF=${SF}..."

--- a/tpchgen-cli/README.md
+++ b/tpchgen-cli/README.md
@@ -39,16 +39,16 @@ RUSTFLAGS='-C target-cpu=native' cargo install tpchgen-cli
 ```shell
 # Scale Factor 10, all tables, in Apache Parquet format in the current directory
 # (3.6GB, 8 files, 60M lineitem rows, in 5 seconds on a modern laptop)
-tpchgen-cli -s 10 --format=parquet
+tpchgen-cli -s 10 --format=parquet --dists-path dists.dss
 
 # Scale Factor 10, all tables, in `tbl`(csv like) format in the `sf10` directory
 # (10GB, 8 files, 60M lineitem rows)
-tpchgen-cli -s 10 --output-dir sf10
+tpchgen-cli -s 10 --output-dir sf10 --dists-path dists.dss
 
-# Scale Factor 1000, lineitem table, in Apache Parquet format in sf1000 directory, 
+# Scale Factor 1000, lineitem table, in Apache Parquet format in sf1000 directory,
 # 20 part(ititons), 100MB row groups
 # (220GB, 20 files, 6B lineitem rows, 3.5 minutes on a modern laptop)
-tpchgen-cli -s 1000 --tables lineitem --parts 20 --format=parquet --parquet-row-group-bytes=100000000 --output-dir sf1000
+tpchgen-cli -s 1000 --tables lineitem --parts 20 --format=parquet --parquet-row-group-bytes=100000000 --output-dir sf1000 --dists-path dists.dss
 
 # Scale Factor 10, partition 2 and 3 of 10 in sf10 directory
 #
@@ -59,15 +59,15 @@ tpchgen-cli -s 1000 --tables lineitem --parts 20 --format=parquet --parquet-row-
 # └── orders
 #    ├── orders.2.tbl
 #    └── orders.3.tbl
-#     
+#
 for PART in `seq 2 3`; do
-  tpchgen-cli --tables lineitem,orders --scale-factor=10 --output-dir partitioned --parts 10 --part $PART
+  tpchgen-cli --tables lineitem,orders --scale-factor=10 --output-dir partitioned --parts 10 --part $PART --dists-path dists.dss
 done
 ```
 
-## Custom distributions
+## Distributions file
 
-To use a custom distribution file, pass `--dists-path`:
+A distributions file must be specified using `--dists-path`:
 
 ```shell
 # load distributions from my.dss

--- a/tpchgen-cli/src/main.rs
+++ b/tpchgen-cli/src/main.rs
@@ -134,9 +134,9 @@ struct Cli {
     #[arg(long, default_value_t = DEFAULT_PARQUET_ROW_GROUP_BYTES)]
     parquet_row_group_bytes: i64,
 
-    /// Path to a custom distributions file
+    /// Path to the distributions file
     #[arg(long)]
-    dists_path: Option<PathBuf>,
+    dists_path: PathBuf,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -252,9 +252,7 @@ async fn main() -> io::Result<()> {
 impl Cli {
     /// Main function to run the generation
     async fn main(self) -> io::Result<()> {
-        if let Some(path) = &self.dists_path {
-            Distributions::init_from_path(path)?;
-        }
+        Distributions::init_from_path(&self.dists_path)?;
 
         if self.verbose {
             // explicitly set logging to info / stdout

--- a/tpchgen-cli/tests/cli_integration.rs
+++ b/tpchgen-cli/tests/cli_integration.rs
@@ -10,14 +10,20 @@ use tempfile::tempdir;
 use tpchgen::generators::OrderGenerator;
 use tpchgen_arrow::{OrderArrow, RecordBatchIterator};
 
+fn tpchgen_cmd() -> Command {
+    let dists = Path::new(env!("CARGO_MANIFEST_DIR")).join("../tpchgen/src/dists.dss");
+    let mut cmd = Command::cargo_bin("tpchgen-cli").expect("Binary not found");
+    cmd.arg("--dists-path").arg(dists);
+    cmd
+}
+
 /// Test TBL output for scale factor 0.001 using tpchgen-cli
 #[test]
 fn test_tpchgen_cli_tbl_scale_factor_0_001() {
     let temp_dir = tempdir().expect("Failed to create temporary directory");
 
     // Run the tpchgen-cli command
-    Command::cargo_bin("tpchgen-cli")
-        .expect("Binary not found")
+    tpchgen_cmd()
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--output-dir")
@@ -73,8 +79,7 @@ fn test_tpchgen_cli_tbl_no_overwrite() {
     let expected_file = temp_dir.path().join("part.tbl");
 
     let run_command = || {
-        Command::cargo_bin("tpchgen-cli")
-            .expect("Binary not found")
+        tpchgen_cmd()
             .arg("--scale-factor")
             .arg("0.001")
             .arg("--tables")
@@ -113,8 +118,7 @@ fn test_tpchgen_cli_parquet_no_overwrite() {
     let expected_file = temp_dir.path().join("part.parquet");
 
     let run_command = || {
-        Command::cargo_bin("tpchgen-cli")
-            .expect("Binary not found")
+        tpchgen_cmd()
             .arg("--scale-factor")
             .arg("0.001")
             .arg("--tables")
@@ -159,8 +163,7 @@ fn test_tpchgen_cli_parts() {
 
     let num_parts = 4;
     let output_dir = temp_dir.path().to_path_buf();
-    Command::cargo_bin("tpchgen-cli")
-        .expect("Binary not found")
+    tpchgen_cmd()
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--output-dir")
@@ -190,8 +193,7 @@ fn test_tpchgen_cli_parts_explicit() {
         threads.push(std::thread::spawn(move || {
             // Run the tpchgen-cli command for each part
             // output goes into `output_dir/orders/orders.{part}.tbl`
-            Command::cargo_bin("tpchgen-cli")
-                .expect("Binary not found")
+            tpchgen_cmd()
                 .arg("--scale-factor")
                 .arg("0.001")
                 .arg("--output-dir")
@@ -220,8 +222,7 @@ fn test_tpchgen_cli_parts_all_tables() {
 
     let num_parts = 8;
     let output_dir = temp_dir.path().to_path_buf();
-    Command::cargo_bin("tpchgen-cli")
-        .expect("Binary not found")
+    tpchgen_cmd()
         .arg("--scale-factor")
         .arg("0.001")
         .arg("--output-dir")
@@ -272,8 +273,7 @@ async fn test_write_parquet_orders() {
     // Run the CLI command to generate parquet data
     let output_dir = tempdir().unwrap();
     let output_path = output_dir.path().join("orders.parquet");
-    Command::cargo_bin("tpchgen-cli")
-        .expect("Binary not found")
+    tpchgen_cmd()
         .arg("--format")
         .arg("parquet")
         .arg("--tables")
@@ -318,8 +318,7 @@ async fn test_write_parquet_orders() {
 async fn test_write_parquet_row_group_size_default() {
     // Run the CLI command to generate parquet data with default settings
     let output_dir = tempdir().unwrap();
-    Command::cargo_bin("tpchgen-cli")
-        .expect("Binary not found")
+    tpchgen_cmd()
         .arg("--format")
         .arg("parquet")
         .arg("--scale-factor")
@@ -386,8 +385,7 @@ async fn test_write_parquet_row_group_size_default() {
 async fn test_write_parquet_row_group_size_20mb() {
     // Run the CLI command to generate parquet data with larger row group size
     let output_dir = tempdir().unwrap();
-    Command::cargo_bin("tpchgen-cli")
-        .expect("Binary not found")
+    tpchgen_cmd()
         .arg("--format")
         .arg("parquet")
         .arg("--scale-factor")
@@ -447,8 +445,7 @@ fn test_tpchgen_cli_part_no_parts() {
     let temp_dir = tempdir().expect("Failed to create temporary directory");
 
     // CLI Error test --part and but not --parts
-    Command::cargo_bin("tpchgen-cli")
-        .expect("Binary not found")
+    tpchgen_cmd()
         .arg("--output-dir")
         .arg(temp_dir.path())
         .arg("--part")
@@ -465,8 +462,7 @@ fn test_tpchgen_cli_too_many_parts() {
     let temp_dir = tempdir().expect("Failed to create temporary directory");
 
     // This should fail because --part is 42 which is more than the --parts 10
-    Command::cargo_bin("tpchgen-cli")
-        .expect("Binary not found")
+    tpchgen_cmd()
         .arg("--output-dir")
         .arg(temp_dir.path())
         .arg("--part")
@@ -484,8 +480,7 @@ fn test_tpchgen_cli_too_many_parts() {
 fn test_tpchgen_cli_zero_part() {
     let temp_dir = tempdir().expect("Failed to create temporary directory");
 
-    Command::cargo_bin("tpchgen-cli")
-        .expect("Binary not found")
+    tpchgen_cmd()
         .arg("--output-dir")
         .arg(temp_dir.path())
         .arg("--part")
@@ -502,8 +497,7 @@ fn test_tpchgen_cli_zero_part() {
 fn test_tpchgen_cli_zero_part_zero_parts() {
     let temp_dir = tempdir().expect("Failed to create temporary directory");
 
-    Command::cargo_bin("tpchgen-cli")
-        .expect("Binary not found")
+    tpchgen_cmd()
         .arg("--output-dir")
         .arg(temp_dir.path())
         .arg("--part")
@@ -521,8 +515,7 @@ fn test_tpchgen_cli_zero_part_zero_parts() {
 #[tokio::test]
 async fn test_incompatible_options_warnings() {
     let output_dir = tempdir().unwrap();
-    Command::cargo_bin("tpchgen-cli")
-        .expect("Binary not found")
+    tpchgen_cmd()
         .arg("--format")
         .arg("csv")
         .arg("--tables")


### PR DESCRIPTION
## Summary
- require providing a distribution file via `--dists-path`
- update documentation and tests for mandatory distribution path

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bb17ad3070832c86328ff4e60a317c